### PR TITLE
Changed comments name inside grammar

### DIFF
--- a/grammars/rainmeter.cson
+++ b/grammars/rainmeter.cson
@@ -77,7 +77,7 @@ patterns: [
   ]}
 
   # Meters and Measures
-  {begin: '(?i)^\\s*(\\[(?!Rainmeter|Variables|Metadata)\\w+\\])\\s*$'
+  {begin: '(?i)^\\s*(\\[(?!Rainmeter|Variables|Metadata)[^\\s#@%]+\\])\\s*$'
   beginCaptures: {1: {name: 'section.rainmeter'}}
   end: '(?=^\\s*\\[)'
   patterns: [

--- a/grammars/rainmeter.cson
+++ b/grammars/rainmeter.cson
@@ -243,7 +243,7 @@ repository:
   # Comments
   comments:
     match: '^\\s*;.*$'
-    name: 'comment.rainmeter'
+    name: 'comment.line.rainmeter'
 
   # @include
   include:


### PR DESCRIPTION
Changed comments name to 'comment.line.rainmeter' to get better consistency
with other languages (e.g. [python](https://github.com/atom/language-python) and [c](https://github.com/atom/language-c)). This also stresses that the comment is a line comment.

From a more pragmatic point of view, it enables the [custom-folds](https://github.com/bsegraves/custom-folds) package to graphically highligh the beginning and end of a custom fold region.
