### PR TITLE
Add coverage for missing options and fix deprecated selectors

### DIFF
--- a/grammars/rainmeter.cson
+++ b/grammars/rainmeter.cson
@@ -136,6 +136,10 @@ patterns: [
     captures:
       1: {name: 'option.rainmeter'}
       2: {name: 'value.constant.rainmeter'}}
+    {match: '(?i)^\\s*(FontWeight)\\s*=\\s*"?(100|200|300|400|500|600|700|800|900|950)"?\\s*$'
+    captures:
+      1: {name: 'option.rainmeter'}
+      2: {name: 'value.constant.rainmeter'}}
     {match: '(?i)^\\s*((?!InlineSetting1)InlineSetting\\d*)\\s*=\\s*"?((Face|Size|Color|Weight|CharacterSpacing|Typography|GradientColor|Stretch)(?=\\s*\\|.*)|(Italic|Oblique|Un"?derline|Strikethrough|None)\\s*$)'
     captures:
       1: {name: 'option.rainmeter'}
@@ -317,7 +321,7 @@ repository:
   bangs:
     patterns: [
       # Normal
-      {match: '(?i)!(Set(Clip|Wallpaper)|About|Manage|TrayMenu|Log|ResetStats|LoadLayout|RefreshApp|Quit|SetOption(Group)?|WriteKeyValue|SetVariable(Group)?|Toggle(Group|Config)?|Move(Meter)?|DeactivateConfig(Group)?|ActivateConfig|Refresh(Group)?|Redraw(Group)?|SetTransparency(Group)?|(Show|Hide|Toggle)Fade(Group)?|(Show|Hide|Toggle|Add|Remove)Blur|Draggable(Group)?|ZPos(Group)?|KeepOnScreen(Group)?|ClickThrough(Group)?|SnapEdges(Group)?|SkinMenu|(Show|Hide|Toggle|Update)Meter(Group)?|((Dis|En)able|Toggle|Update)Measure(Group)?|CommandMeasure|(Un|Toggle)?PauseMeasure|(Show|Hide)(Group)?|Update|LoadLayout)\\b'
+      {match: '(?i)!(Set(Clip|Wallpaper)|About|Manage|TrayMenu|Log|ResetStats|LoadLayout|RefreshApp|Quit|SetOption(Group)?|WriteKeyValue|SetVariable(Group)?|Toggle(Group|Config)?|Move(Meter)?|DeactivateConfig(Group)?|ActivateConfig|Refresh(Group)?|Redraw(Group)?|SetTransparency(Group)?|(Show|Hide|Toggle)Fade(Group)?|(Show|Hide|Toggle|Add|Remove)Blur|Draggable(Group)?|ZPos(Group)?|KeepOnScreen(Group)?|ClickThrough(Group)?|SnapEdges(Group)?|SkinMenu|(Show|Hide|Toggle|Update)Meter(Group)?|((Dis|En)able|Toggle|Update)Measure(Group)?|CommandMeasure|(Un|Toggle)?PauseMeasure|(Show|Hide)(Group)?|Update|LoadLayout|FadeDuration(Group)?)\\b'
       name: 'support.function.rainmeter'}
       # Deprecated
       {match: '(?i)!(Rainmeter(SetClip|SetWallpaper|About|Manage|Log|LsBoxHook|ResetStats|TrayMenu|RefreshApp|Quit|(SetOptionGroup?)|WriteKeyValue|(SetVariableGroup?)|Toggle(Group|Config)?|Move(Meter)?|DeactivateConfig(Group)?|ActivateConfig|Refresh(Group)?|Redraw(Group)?|SetTransparency(Group)?|(Show|Hide|Toggle)Fade(Group)?|(Show|Hide|Toggle|Add|Remove)Blur|Draggable(Group)?|ZPos(Group)?|KeepOnScreen(Group)?|ClickThrough(Group)?|SnapEdges(Group)?|SkinMenu|(Show|Hide|Toggle|Update)Meter(Group)?|((Dis|En)able|Toggle|Update)Measure(Group)?|CommandMeasure|(Un|Toggle)?PauseMeasure|(Show|Hide)(Group)?|Update|LoadLayout)|Execute|(Rainmeter)?PluginBang)\\b'
@@ -327,7 +331,7 @@ repository:
   # All math functions and constants
   math:
     patterns: [
-      {match: '(?i)\\b(((a)?(tan|sin|cos))|abs|exp|log|ln|sqrt|sgn|frac|trunc|floor|ceil|round|rad|min|max|clamp)\\s*(?=\\()'
+      {match: '(?i)\\b(((a)?(tan|sin|cos))|abs|exp|log|ln|sqrt|sgn|frac|trunc|floor|ceil|round|rad|deg|min|max|clamp)\\s*(?=\\()'
       name: 'support.function.rainmeter'}
       {match: '(?i)\\b(PI|E)\\b'
       name: 'support.function.constant.rainmeter'}

--- a/grammars/rainmeter.cson
+++ b/grammars/rainmeter.cson
@@ -336,7 +336,7 @@ repository:
   # All options that require bangs
   meterActionOptions:
     patterns: [
-      {begin: '(?i)^\\s*(((Left|Right|Middle|X(1|2))Mouse(Up|Down|DoubleClick)|Mouse(Over|Leave|Scroll(Up|Down|Left|Right))|OnUpdate)Action|(?!If(Above|Below|Equal)Action1)If(Above|Below|Equal)Action\\d*|(?!If(Match|NotMatch)Action1)If(Match|NotMatch)Action\\d*|(?!If(True|False)Action1)If(True|False)Action\\d*|MouseActionCursor(Name)?)\\s*='
+      {begin: '(?i)^\\s*(((Left|Right|Middle|X(1|2))Mouse(Up|Down|DoubleClick)|Mouse(Over|Leave|Scroll(Up|Down|Left|Right))|OnUpdate)Action|(?!If(Above|Below|Equal)Action1)If(Above|Below|Equal)Action\\d*|(?!If(Match|NotMatch)Action1)If(Match|NotMatch)Action\\d*|(?!If(True|False)Action1)If(True|False)Action\\d*|MouseActionCursor(Name)?|OnChangeAction)\\s*='
       beginCaptures: {1: {name: 'option.rainmeter'}}
       end: '$'
       patterns: [

--- a/grammars/rainmeter.cson
+++ b/grammars/rainmeter.cson
@@ -347,7 +347,7 @@ repository:
 
   colors:
     patterns: [
-      {match: '(?i)(\\d+),\\s*(\\d+),\\s*(\\d+)(?:,\\s*(\\d+))?|(?<=[= \"])([0-9a-f]{2})([0-9a-f]{2})([0-9a-f]{2})([0-9a-f]{2})?[\\s\"]'
+      {match: '(?i)(\\d+),\\s*(\\d+),\\s*(\\d+)(?:,\\s*(\\d+))?|(?<=[= \"])([0-9a-f]{2})([0-9a-f]{2})([0-9a-f]{2})([0-9a-f]{2})?'
       captures:
         1: {name: 'color.r.rainmeter'}
         2: {name: 'color.g.rainmeter'}

--- a/styles/rainmeter.atom-text-editor.less
+++ b/styles/rainmeter.atom-text-editor.less
@@ -1,83 +1,83 @@
 @import "syntax-variables";
 
-.source.rainmeter{
-  .section,
-  .predefined.section{
+.syntax--source.syntax--rainmeter{
+  .syntax--section,
+  .syntax--predefined.syntax--section{
     color: @syntax-color-function;
   }
 
-  .predefined.section{
+  .syntax--predefined.syntax--section{
     font-weight: bold;
   }
 
-  .variable,
-  .predefined.variable{
+  .syntax--variable,
+  .syntax--predefined.syntax--variable{
     color: @syntax-color-variable;
   }
 
-  .predefined.variable{
+  .syntax--predefined.syntax--variable{
     font-style: italic;
   }
 
-  .section.variable{
+  .syntax--section.syntax--variable{
     color: @syntax-color-snippet;
     background-color: rgba(red(@syntax-color-snippet), green(@syntax-color-snippet), blue(@syntax-color-snippet), 0.1);
   }
 
-  .section.variable.arg{
+  .syntax--section.syntax--variable.syntax--arg{
     color: @syntax-color-constant;
   }
 
-  .invalid{
+  .syntax--invalid{
     color: white;
     background-color: @syntax-color-removed;
   }
 
-  .support.function{
+  .syntax--support.syntax--function{
     font-style: italic;
   }
 
-  .support.function.constant{
+  .syntax--support.syntax--function.syntax--constant{
     font-style: normal;
   }
 
-  .deprecated.function{
+  .syntax--deprecated.syntax--function{
     color: darken(@syntax-color-modified, 50%);
     background-color: @syntax-color-modified;
     font-style: normal;
   }
 
-  .option{
+  .syntax--option{
     color: @syntax-color-keyword;
   }
 
-  .meter.style.option{
+  .syntax--meter.syntax--style.syntax--option{
     font-style: italic;
   }
 
-  .include{
+  .syntax--include{
     font-style: italic;
     font-weight: bold;
   }
 
-  .value.constant{
+  .syntax--value.syntax--constant{
     color: @syntax-color-class;
   }
 
-  .value.constant.important{
+  .syntax--value.syntax--constant.syntax--important{
     font-weight: bold;
   }
 
-  .color.r{
+  .syntax--color.syntax--r{
     color: #FF5151;
   }
-  .color.g{
+  .syntax--color.syntax--g{
     color: #00D200;
   }
-  .color.b{
+  .syntax--color.syntax--b{
     color: #6262FF;
   }
-  .color.a{
+  .syntax--color.syntax--a{
     color: #AAAAAA;
   }
 }


### PR DESCRIPTION
As usual, feel free to make changes as you see fit and let me know if there's anything you'd like me to change.

* **Fixed issue #14** - Updated deprecated selectors for Atom v1.13
* Added coverage for [OnChangeAction](https://docs.rainmeter.net/manual-beta/measures/general-options/#OnChangeAction) measure option
* Fixed an issue that was causing hex colors without trailing whitespace to prevent the highlighting of the option on the following line (*shown below*)
![example](https://user-images.githubusercontent.com/16360374/27311373-51a2a608-5515-11e7-845e-7dfcab1a1959.png)
 * **For Rainmeter [v4.1](https://www.rainmeter.net/beta-4-1):**
   * Added coverage for new [Deg](https://docs.rainmeter.net/manual-beta/formulas/#Functions) math function
   *  Added coverage for [FontWeight](https://docs.rainmeter.net/manual-beta/meters/string/#FontWeight) string option
   * Added coverage for !FadeDuration and !FadeDurationGroup bangs for setting [FadeDuration](https://docs.rainmeter.net/manual-beta/settings/skin-sections/#FadeDuration) when activating/deactivating a skin

***Edit:*** I was unaware of the existing pull request that acknowledges the issue of the deprecated selectors, so if you'd prefer I can resubmit this pull request without those changes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nighthawkslo/language-rainmeter/16)
<!-- Reviewable:end -->
