### PR TITLE
Add issue and pull request templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,25 @@
+### Prerequisites
+
+* [ ] You are using the most recent release of **language-rainmeter**
+* [ ] You have checked that your issue hasn't already been addressed by an [existing issue](https://github.com/MarcoPixel/language-rainmeter/issues?utf8=%E2%9C%93&q=is%3Aissue)
+
+### Description
+
+[Description of the issue or enhancement]
+
+### Steps to Reproduce
+
+1. [First Step]
+2. [Second Step]
+3. [and so on...]
+
+**Expected behavior:** [What you expect to happen]
+
+**Actual behavior:** [What actually happens]
+
+**Reproduces how often:** [What percentage of the time does it reproduce?]  
+
+
+### Additional Information
+
+Any additional information, configuration or data that might be necessary to reproduce the issue.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,12 @@
+
+### Types of Changes
+ - [ ] Fix (fixes a reported issue) 
+ - [ ] New feature (adds additional functionality)
+
+### Proposed Changes:  
+  - [Fixes #(corresponding issue number)]
+  -   
+  -   
+
+### Additional Information
+If this pull request features relatively large or undiscussed changes, explain the motivation or benefits of the proposed changes. 


### PR DESCRIPTION
Adding basic templates should make handling future issues/pull requests easier and hopefully prevent duplicate issues.  
Just a suggestion, feel free to modify them however you see fit.