### PR TITLE
Add README badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,29 +1,36 @@
-# Rainmeter language syntax
+# Rainmeter language syntax  
 
-Adds syntax highlighting for Rainmeter files in Atom.
+Adds syntax highlighting for Rainmeter files in Atom.  
 
-## Screenshot
+[![version](https://img.shields.io/apm/v/language-rainmeter.svg)](https://github.com/MarcoPixel/language-rainmeter/releases/latest)
+[![issues](https://img.shields.io/github/issues/MarcoPixel/language-rainmeter.svg)](https://github.com/MarcoPixel/language-rainmeter/issues)
+[![license](https://img.shields.io/apm/l/language-rainmeter.svg)](https://github.com/MarcoPixel/language-rainmeter/blob/master/LICENSE.md)
+[![downloads](https://img.shields.io/apm/dm/language-rainmeter.svg)](https://atom.io/packages/language-rainmeter)
+<!-- We can uncomment this once merging the ci-testing branck -->
+<!-- [![travis CI](https://img.shields.io/travis/MarcoPixel/language-rainmeter.svg)](https://travis-ci.org/MarcoPixel/language-rainmeter) -->
 
-![Default Theme Screenshot](https://raw.githubusercontent.com/MarcoPixel/marcopixel.github.io/master/img/Atom.png "Default Theme Screenshot")
+## Screenshot  
 
-## Install
+![Default Theme Screenshot](https://raw.githubusercontent.com/MarcoPixel/marcopixel.github.io/master/img/Atom.png "Default Theme Screenshot")  
+
+## Install  
 
 ```bash
 $ apm install language-rainmeter
 ```
 
-Or Settings ➔ Packages ➔ Search for `language-rainmeter`
+Or Settings ➔ Packages ➔ Search for `language-rainmeter`  
 
-# Contributing & Issues
+# Contributing & Issues  
 
-Contributions are greatly appreciated. Please fork this repository and open a pull request to add snippets, make grammar tweaks, etc.
+Contributions are greatly appreciated. Please fork this repository and open a pull request to add snippets, make grammar tweaks, etc.  
 
-If you find any bugs or issues, please report them [here](https://github.com/MarcoPixel/language-rainmeter/issues). Please follow the existing template and fill out the necessary information, otherwise the issue will be closed.
+If you find any bugs or issues, please report them [here](https://github.com/MarcoPixel/language-rainmeter/issues). Please follow the existing template and fill out the necessary information, otherwise the issue will be closed.  
 
-# License
+# License  
 
-[MIT](https://github.com/MarcoPixel/language-rainmeter/blob/master/LICENSE.md) © [Marco Vockner](https://github.com/MarcoPixel)
+[MIT](https://github.com/MarcoPixel/language-rainmeter/blob/master/LICENSE.md) © [Marco Vockner](https://github.com/MarcoPixel)  
 
-# Authors
+# Authors  
 
-**Original author:** NighthawkSLO (https://github.com/NighthawkSLO)
+**Original author:** NighthawkSLO (https://github.com/NighthawkSLO)  


### PR DESCRIPTION
### Types of Changes
 - [ ] Fix (fixes a reported issue) 
 - [x] New feature (adds additional functionality)

### Proposed Changes:  
  - Add *apm* badges to the README

### Additional Information
Though the file comparison seems to think otherwise, all I did was add a few badges that I thought would be helpful, including a badge for the Travis CI status that can be uncommented once the `add-ci-code-testing` branch is merged.  Feel free to move them around or modify them however you like.  
  
  
***Note:*** I'll also be able to take another look at the spec for the testing branch soon, as I've been without a windows machine for the last couple weeks.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/marcopixel/language-rainmeter/22)
<!-- Reviewable:end -->
